### PR TITLE
feat: add Prometheus metrics support to command processors and mailtx

### DIFF
--- a/mailmux/src/metrics.rs
+++ b/mailmux/src/metrics.rs
@@ -70,3 +70,34 @@ pub fn add_idle_heartbeat_catches(account: &str, mailbox: &str, count: u64) {
     counter!("mailmux_idle_heartbeat_catches_total", "account" => account.to_owned(), "mailbox" => mailbox.to_owned())
         .increment(count);
 }
+
+/// Record metrics emitted by a processor in its `ProcessorOutput`.
+/// Each metric is namespaced as `mailmux_proc_{processor_name}_{metric_name}`.
+pub fn record_processor_metrics(
+    processor_name: &str,
+    metrics: &[crate::processor::ProcessorMetric],
+) {
+    use crate::processor::MetricKind;
+
+    for m in metrics {
+        let full_name = format!("mailmux_proc_{}_{}", processor_name, m.name);
+        let labels: Vec<(&'static str, String)> = m
+            .labels
+            .iter()
+            .map(|(k, v)| {
+                // Leak the key string so we get a `&'static str` required by the metrics macros.
+                let key: &'static str = Box::leak(k.clone().into_boxed_str());
+                (key, v.clone())
+            })
+            .collect();
+
+        match m.kind {
+            MetricKind::Counter => {
+                counter!(full_name, &labels).increment(m.value as u64);
+            }
+            MetricKind::Gauge => {
+                gauge!(full_name, &labels).set(m.value);
+            }
+        }
+    }
+}

--- a/mailmux/src/processor/builtin/command.rs
+++ b/mailmux/src/processor/builtin/command.rs
@@ -121,6 +121,11 @@ impl Processor for CommandProcessor {
                 stdout = %stdout,
                 "command completed successfully"
             );
+            // Try to parse stdout as a structured ProcessorOutput so the command can
+            // emit metrics. Fall back to treating stdout as a plain message string.
+            if let Ok(parsed) = serde_json::from_str::<ProcessorOutput>(stdout.as_ref()) {
+                return Ok(parsed);
+            }
             Ok(ProcessorOutput {
                 success: true,
                 message: if stdout.is_empty() {
@@ -129,6 +134,7 @@ impl Processor for CommandProcessor {
                     Some(stdout.into_owned())
                 },
                 metadata: None,
+                metrics: vec![],
             })
         } else {
             let code = output.status.code().unwrap_or(-1);
@@ -149,6 +155,7 @@ impl Processor for CommandProcessor {
                     }
                 )),
                 metadata: None,
+                metrics: vec![],
             })
         }
     }

--- a/mailmux/src/processor/builtin/logger.rs
+++ b/mailmux/src/processor/builtin/logger.rs
@@ -51,6 +51,7 @@ impl Processor for LoggerProcessor {
             success: true,
             message: Some("logged".to_string()),
             metadata: None,
+            metrics: vec![],
         })
     }
 }

--- a/mailmux/src/processor/mod.rs
+++ b/mailmux/src/processor/mod.rs
@@ -2,6 +2,8 @@ pub mod builtin;
 pub mod registry;
 pub mod scheduler;
 
+use std::collections::HashMap;
+
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -9,12 +11,34 @@ use serde::{Deserialize, Serialize};
 use crate::db::emails::EmailRecord;
 use crate::db::events::Event;
 
+/// The kind of metric a processor wants to emit.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MetricKind {
+    Counter,
+    Gauge,
+}
+
+/// A single metric emitted by a processor as part of its output.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProcessorMetric {
+    /// Metric name, e.g. `"notifications_sent"`. Will be namespaced by the scheduler.
+    pub name: String,
+    pub kind: MetricKind,
+    pub value: f64,
+    #[serde(default)]
+    pub labels: HashMap<String, String>,
+}
+
 /// Output from a processor execution.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ProcessorOutput {
     pub success: bool,
     pub message: Option<String>,
     pub metadata: Option<serde_json::Value>,
+    /// Optional metrics to record after this run.
+    #[serde(default)]
+    pub metrics: Vec<ProcessorMetric>,
 }
 
 /// Trait that all processors must implement.

--- a/mailmux/src/processor/scheduler.rs
+++ b/mailmux/src/processor/scheduler.rs
@@ -187,6 +187,9 @@ impl JobScheduler {
                 let _ = jobs::update_job_status(&self.pool, job_id, "completed", None, None, false)
                     .await;
                 crate::metrics::inc_processor_runs(processor_name, "success");
+                if !output.metrics.is_empty() {
+                    crate::metrics::record_processor_metrics(processor_name, &output.metrics);
+                }
             }
             Ok(Ok(output)) => {
                 let msg = output.message.unwrap_or_default();

--- a/mailtx/README.md
+++ b/mailtx/README.md
@@ -100,6 +100,64 @@ monetary amount, `"not_found"` otherwise. Processing stops without error when
 Posted to `POST /v1/transactions` under your Firefly API base URL with
 `Authorization: Bearer <token>`.
 
+## Metrics
+
+mailtx emits Prometheus metrics via mailmux's command processor stdout protocol.
+Each invocation writes a `ProcessorOutput` JSON object to stdout; mailmux reads
+it and registers the metrics under the `mailmux_proc_mailtx_` namespace in its
+`/metrics` endpoint.
+
+### Metric reference
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `mailmux_proc_mailtx_emails_processed_total` | counter | `result` | One increment per invocation, labelled with the terminal outcome |
+| `mailmux_proc_mailtx_llm_calls_total` | counter | `result` | LLM API calls attempted |
+| `mailmux_proc_mailtx_firefly_requests_total` | counter | `operation`, `result` | Firefly HTTP requests made |
+| `mailmux_proc_mailtx_account_match_total` | counter | `method` | Account-resolution attempts and the method used |
+| `mailmux_proc_mailtx_transfer_legs_stored_total` | counter | — | Transfer legs stored pending a counterpart |
+| `mailmux_proc_mailtx_transfer_coalesced_total` | counter | — | Transfers successfully coalesced from two legs |
+| `mailmux_proc_mailtx_transfer_expired_total` | counter | — | Expired transfer legs flushed as unmatched transactions |
+
+### Label values
+
+**`emails_processed_total{result=…}`**
+
+| Value | Meaning |
+|---|---|
+| `skipped_sender` | Sender not in allow-list, or no email record attached |
+| `no_transaction` | LLM returned `status=not_found` |
+| `posted` | Regular transaction posted to Firefly |
+| `transfer_stored` | First leg of a transfer stored; waiting for counterpart |
+| `transfer_coalesced` | Both transfer legs matched; transfer posted to Firefly |
+| `error` | Invocation failed (non-zero exit) |
+
+**`llm_calls_total{result=…}`**
+
+| Value | Meaning |
+|---|---|
+| `success` | LLM responded and JSON was parsed successfully |
+| `error` | API call failed or JSON parse of the response failed |
+
+**`firefly_requests_total{operation=…, result=…}`**
+
+| `operation` | Meaning |
+|---|---|
+| `get_categories` | `GET /v1/categories` (fetched once per eligible email) |
+| `post_transaction` | `POST /v1/transactions` (regular, transfer, or expired-leg flush) |
+
+`result` is `success` or `error`.
+
+**`account_match_total{method=…}`**
+
+| Value | Matching strategy used |
+|---|---|
+| `debit_card_last4` | Card number last-4 digits found in email |
+| `account_suffix` | Account suffix found in email |
+| `alias` | Alias substring match |
+| `default_fallback` | `default_asset_account_id` used |
+| `failed` | No account could be resolved (invocation errors out) |
+
 ## Prerequisites
 
 - Rust 1.80+ (edition 2024) — for `std::sync::LazyLock`

--- a/mailtx/src/main.rs
+++ b/mailtx/src/main.rs
@@ -1,8 +1,10 @@
 use std::io::Read;
 
-use crate::matcher::AccountMatcher;
 use anyhow::Result;
 use tracing::{info, warn};
+
+use crate::matcher::AccountMatcher;
+use crate::metrics::Metrics;
 
 mod config;
 mod email;
@@ -10,17 +12,11 @@ mod endpoint;
 mod input;
 mod llm;
 mod matcher;
+mod metrics;
 mod transfer;
 
 #[tokio::main]
 async fn main() {
-    if let Err(e) = run().await {
-        eprintln!("error: {e:#}");
-        std::process::exit(1);
-    }
-}
-
-async fn run() -> Result<()> {
     // Log to stderr — stdout is read by mailmux as the processor result.
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
@@ -30,6 +26,32 @@ async fn run() -> Result<()> {
         )
         .init();
 
+    let mut m = Metrics::default();
+    let success = match run(&mut m).await {
+        Ok(()) => true,
+        Err(e) => {
+            eprintln!("error: {e:#}");
+            if m.result.is_none() {
+                m.result = Some("error");
+            }
+            false
+        }
+    };
+
+    // Always write a ProcessorOutput JSON object to stdout so mailmux can
+    // register the accumulated metrics in its Prometheus endpoint.
+    let output = m.into_output(success);
+    match serde_json::to_string(&output) {
+        Ok(json) => println!("{json}"),
+        Err(e) => eprintln!("failed to serialise processor output: {e}"),
+    }
+
+    if !success {
+        std::process::exit(1);
+    }
+}
+
+async fn run(m: &mut Metrics) -> Result<()> {
     let config = config::Config::load()?;
     let endpoint = endpoint::build_endpoint(&config);
     let http_client = reqwest::Client::new();
@@ -77,6 +99,8 @@ async fn run() -> Result<()> {
                         "expired transfer leg flushed as unmatched transaction"
                     );
                     store.delete(expired.id)?;
+                    m.firefly_requests.push(("post_transaction", "success"));
+                    m.transfers_expired += 1;
                 }
                 Err(e) => {
                     warn!(
@@ -84,6 +108,7 @@ async fn run() -> Result<()> {
                         id = expired.id,
                         "failed to flush expired transfer leg; will retry next run"
                     );
+                    m.firefly_requests.push(("post_transaction", "error"));
                 }
             }
         }
@@ -109,6 +134,7 @@ async fn run() -> Result<()> {
                 event_id = input.event.id,
                 "no email record attached to event, skipping"
             );
+            m.result = Some("skipped_sender");
             return Ok(());
         }
     };
@@ -116,6 +142,7 @@ async fn run() -> Result<()> {
     let sender = email.sender.as_deref().unwrap_or("");
     if !config.sender_allowed(sender) {
         info!(sender, "sender not in allow-list, skipping");
+        m.result = Some("skipped_sender");
         return Ok(());
     }
 
@@ -127,15 +154,35 @@ async fn run() -> Result<()> {
     let llm_client = genai::Client::default();
 
     // Fetch existing categories from Firefly so the LLM can reuse them.
-    let categories = endpoint.fetch_categories(&http_client).await?;
-    info!(count = categories.len(), "cached Firefly categories");
+    let categories = match endpoint.fetch_categories(&http_client).await {
+        Ok(cats) => {
+            info!(count = cats.len(), "cached Firefly categories");
+            m.firefly_requests.push(("get_categories", "success"));
+            cats
+        }
+        Err(e) => {
+            m.firefly_requests.push(("get_categories", "error"));
+            return Err(e);
+        }
+    };
 
     let tx =
-        llm::extract_transaction(&llm_client, &config.llm_model, subject, &body, &categories)
-            .await?;
+        match llm::extract_transaction(&llm_client, &config.llm_model, subject, &body, &categories)
+            .await
+        {
+            Ok(tx) => {
+                m.llm_result = Some("success");
+                tx
+            }
+            Err(e) => {
+                m.llm_result = Some("error");
+                return Err(e);
+            }
+        };
 
     if tx.status != "found" {
         info!("LLM did not find transaction data in email, skipping");
+        m.result = Some("no_transaction");
         return Ok(());
     }
 
@@ -146,7 +193,16 @@ async fn run() -> Result<()> {
         .filter(|s| !s.is_empty())
         .map(String::from);
 
-    let resolved = account_matcher.resolve_asset_account(subject, &body)?;
+    let resolved = match account_matcher.resolve_asset_account(subject, &body) {
+        Ok(r) => {
+            m.account_match_method = Some(r.method);
+            r
+        }
+        Err(e) => {
+            m.account_match_method = Some("failed");
+            return Err(e);
+        }
+    };
 
     // Build the canonical transaction. For transfers this is reused as a base
     // (struct update) to keep all the shared fields (narration, occurred_at, etc.).
@@ -166,84 +222,102 @@ async fn run() -> Result<()> {
             transfer::detect_transfer_rule(&config, &resolved.account_id, &leg, &canonical_tx.narration)
     {
         let store = pending_store.as_ref().ok_or_else(|| {
-                anyhow::anyhow!(
-                    "transfer rule matched but state_db is not configured \
-                     (this should have been caught at startup)"
-                )
+            anyhow::anyhow!(
+                "transfer rule matched but state_db is not configured \
+                 (this should have been caught at startup)"
+            )
+        })?;
+
+        let amount_units = (canonical_tx.amount.abs() * 100.0).round() as i64;
+
+        if let Some(pending) =
+            store.find_match(&rule_match.rule_id, leg.opposite_str(), amount_units)?
+        {
+            // Both legs are in — post a Firefly transfer transaction.
+            let transfer_tx = endpoint::CanonicalTransaction {
+                kind: endpoint::TransactionKind::Transfer,
+                asset_account_id: rule_match.source_firefly_id.clone(),
+                transfer_destination_account_id: Some(
+                    rule_match.destination_firefly_id.clone(),
+                ),
+                ..canonical_tx
+            };
+            match endpoint.post_transaction(&http_client, &transfer_tx).await {
+                Ok(receipt) => {
+                    store.delete(pending.id)?;
+                    m.firefly_requests.push(("post_transaction", "success"));
+                    m.transfers_coalesced += 1;
+                    m.result = Some("transfer_coalesced");
+                    info!(
+                        endpoint_transaction_id = receipt.id.as_deref(),
+                        amount = transfer_tx.amount,
+                        source_firefly_account_id = transfer_tx.asset_account_id.as_str(),
+                        destination_firefly_account_id =
+                            transfer_tx.transfer_destination_account_id.as_deref(),
+                        narration = transfer_tx.narration.as_str(),
+                        "transfer transaction posted"
+                    );
+                }
+                Err(e) => {
+                    m.firefly_requests.push(("post_transaction", "error"));
+                    return Err(e);
+                }
+            }
+        } else {
+            // First leg — store and wait for the counterpart.
+            store.insert(transfer::InsertLeg {
+                rule_id: &rule_match.rule_id,
+                leg: &rule_match.leg,
+                amount_units,
+                narration: &canonical_tx.narration,
+                category: canonical_tx.category_name.as_deref(),
+                source_firefly_id: &rule_match.source_firefly_id,
+                destination_firefly_id: &rule_match.destination_firefly_id,
+                occurred_at: &canonical_tx.occurred_at,
+                tags: &canonical_tx.tags,
             })?;
-
-            let amount_units = (canonical_tx.amount.abs() * 100.0).round() as i64;
-
-            if let Some(pending) =
-                store.find_match(&rule_match.rule_id, leg.opposite_str(), amount_units)?
-            {
-                // Both legs are in — post a Firefly transfer transaction.
-                let transfer_tx = endpoint::CanonicalTransaction {
-                    kind: endpoint::TransactionKind::Transfer,
-                    asset_account_id: rule_match.source_firefly_id.clone(),
-                    transfer_destination_account_id: Some(
-                        rule_match.destination_firefly_id.clone(),
-                    ),
-                    ..canonical_tx
-                };
-                let receipt = endpoint.post_transaction(&http_client, &transfer_tx).await?;
-                store.delete(pending.id)?;
-                info!(
-                    endpoint_transaction_id = receipt.id.as_deref(),
-                    amount = transfer_tx.amount,
-                    source_firefly_account_id = transfer_tx.asset_account_id.as_str(),
-                    destination_firefly_account_id =
-                        transfer_tx.transfer_destination_account_id.as_deref(),
-                    narration = transfer_tx.narration.as_str(),
-                    "transfer transaction posted"
-                );
-            } else {
-                // First leg — store and wait for the counterpart.
-                store.insert(transfer::InsertLeg {
-                    rule_id: &rule_match.rule_id,
-                    leg: &rule_match.leg,
-                    amount_units,
-                    narration: &canonical_tx.narration,
-                    category: canonical_tx.category_name.as_deref(),
-                    source_firefly_id: &rule_match.source_firefly_id,
-                    destination_firefly_id: &rule_match.destination_firefly_id,
-                    occurred_at: &canonical_tx.occurred_at,
-                    tags: &canonical_tx.tags,
-                })?;
-                info!(
-                    rule_id = rule_match.rule_id.as_str(),
-                    leg = leg.as_str(),
-                    amount = canonical_tx.amount,
-                    narration = canonical_tx.narration.as_str(),
-                    "first transfer leg stored, waiting for counterpart"
-                );
+            m.transfers_stored += 1;
+            m.result = Some("transfer_stored");
+            info!(
+                rule_id = rule_match.rule_id.as_str(),
+                leg = leg.as_str(),
+                amount = canonical_tx.amount,
+                narration = canonical_tx.narration.as_str(),
+                "first transfer leg stored, waiting for counterpart"
+            );
         }
         return Ok(());
     }
     // --- End transfer detection ---------------------------------------------
 
-    // Regular (non-transfer) transaction — existing behaviour.
-    let receipt = endpoint
-        .post_transaction(&http_client, &canonical_tx)
-        .await?;
-
-    info!(
-        endpoint = endpoint.name(),
-        endpoint_transaction_id = receipt.id.as_deref(),
-        amount = canonical_tx.amount,
-        transaction_type = match canonical_tx.kind {
-            endpoint::TransactionKind::Deposit => "deposit",
-            endpoint::TransactionKind::Withdrawal => "withdrawal",
-            endpoint::TransactionKind::Transfer => "transfer",
-        },
-        resolved_account_id = resolved.account_id.as_str(),
-        resolved_firefly_asset_account_id = resolved.firefly_account_id.as_str(),
-        account_match_method = resolved.method,
-        account_match_value = resolved.matched_value.as_deref(),
-        narration = canonical_tx.narration.as_str(),
-        category = canonical_tx.category_name.as_deref().unwrap_or("(none)"),
-        "transaction posted successfully"
-    );
+    // Regular (non-transfer) transaction.
+    match endpoint.post_transaction(&http_client, &canonical_tx).await {
+        Ok(receipt) => {
+            m.firefly_requests.push(("post_transaction", "success"));
+            m.result = Some("posted");
+            info!(
+                endpoint = endpoint.name(),
+                endpoint_transaction_id = receipt.id.as_deref(),
+                amount = canonical_tx.amount,
+                transaction_type = match canonical_tx.kind {
+                    endpoint::TransactionKind::Deposit => "deposit",
+                    endpoint::TransactionKind::Withdrawal => "withdrawal",
+                    endpoint::TransactionKind::Transfer => "transfer",
+                },
+                resolved_account_id = resolved.account_id.as_str(),
+                resolved_firefly_asset_account_id = resolved.firefly_account_id.as_str(),
+                account_match_method = resolved.method,
+                account_match_value = resolved.matched_value.as_deref(),
+                narration = canonical_tx.narration.as_str(),
+                category = canonical_tx.category_name.as_deref().unwrap_or("(none)"),
+                "transaction posted successfully"
+            );
+        }
+        Err(e) => {
+            m.firefly_requests.push(("post_transaction", "error"));
+            return Err(e);
+        }
+    }
 
     Ok(())
 }

--- a/mailtx/src/metrics.rs
+++ b/mailtx/src/metrics.rs
@@ -1,0 +1,117 @@
+use std::collections::HashMap;
+
+use serde::Serialize;
+
+/// Metrics accumulated during a single mailtx invocation.
+///
+/// Converted to a [`ProcessorOutput`] JSON object at the end of every run and
+/// written to stdout so that mailmux's command processor can register them in
+/// its Prometheus endpoint.
+#[derive(Debug, Default)]
+pub struct Metrics {
+    /// Terminal outcome for this invocation.
+    pub result: Option<&'static str>,
+    /// Result of the LLM call, set whenever a call was attempted.
+    pub llm_result: Option<&'static str>,
+    /// Firefly API calls made this run: one `(operation, result)` entry per
+    /// HTTP request.
+    pub firefly_requests: Vec<(&'static str, &'static str)>,
+    /// Account-resolution method used, set whenever resolution was attempted.
+    pub account_match_method: Option<&'static str>,
+    /// Number of transfer legs stored in the pending store this run.
+    pub transfers_stored: u32,
+    /// Number of transfers fully coalesced (both legs matched) this run.
+    pub transfers_coalesced: u32,
+    /// Number of expired transfer legs flushed as unmatched transactions this run.
+    pub transfers_expired: u32,
+}
+
+/// Mirrors mailmux's `ProcessorOutput` schema.
+/// Serialised to stdout so the command processor can forward the metrics.
+#[derive(Serialize)]
+pub struct ProcessorOutput {
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    pub metrics: Vec<ProcessorMetric>,
+}
+
+/// Mirrors mailmux's `ProcessorMetric` schema.
+#[derive(Serialize)]
+pub struct ProcessorMetric {
+    pub name: String,
+    /// `"counter"` or `"gauge"` — matches `MetricKind` serde output in mailmux.
+    pub kind: &'static str,
+    pub value: f64,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub labels: HashMap<String, String>,
+}
+
+impl Metrics {
+    /// Convert into a [`ProcessorOutput`] ready to be serialised to stdout.
+    pub fn into_output(self, success: bool) -> ProcessorOutput {
+        let mut metrics: Vec<ProcessorMetric> = Vec::new();
+
+        if let Some(result) = self.result {
+            metrics.push(counter("emails_processed_total", 1.0, &[("result", result)]));
+        }
+
+        if let Some(result) = self.llm_result {
+            metrics.push(counter("llm_calls_total", 1.0, &[("result", result)]));
+        }
+
+        for (operation, result) in &self.firefly_requests {
+            metrics.push(counter(
+                "firefly_requests_total",
+                1.0,
+                &[("operation", operation), ("result", result)],
+            ));
+        }
+
+        if let Some(method) = self.account_match_method {
+            metrics.push(counter("account_match_total", 1.0, &[("method", method)]));
+        }
+
+        if self.transfers_stored > 0 {
+            metrics.push(counter(
+                "transfer_legs_stored_total",
+                self.transfers_stored as f64,
+                &[],
+            ));
+        }
+
+        if self.transfers_coalesced > 0 {
+            metrics.push(counter(
+                "transfer_coalesced_total",
+                self.transfers_coalesced as f64,
+                &[],
+            ));
+        }
+
+        if self.transfers_expired > 0 {
+            metrics.push(counter(
+                "transfer_expired_total",
+                self.transfers_expired as f64,
+                &[],
+            ));
+        }
+
+        ProcessorOutput {
+            success,
+            message: None,
+            metrics,
+        }
+    }
+}
+
+fn counter(name: &str, value: f64, labels: &[(&str, &str)]) -> ProcessorMetric {
+    ProcessorMetric {
+        name: name.to_owned(),
+        kind: "counter",
+        value,
+        labels: labels
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect(),
+    }
+}


### PR DESCRIPTION
## Summary

- **mailmux**: Extends the command processor stdout protocol so processors can emit custom Prometheus metrics. `ProcessorOutput` gains a `metrics` field; the scheduler namespaces and registers them as `mailmux_proc_{processor}_{name}` after each successful run.
- **mailtx**: Implements the protocol with a new `metrics.rs` module that accumulates counters throughout the pipeline and writes a `ProcessorOutput` JSON object to stdout on every exit.
- **docs**: README updated with a full metrics reference table including all label values.

## Metrics emitted by mailtx

| Metric | Labels |
|---|---|
| `mailmux_proc_mailtx_emails_processed_total` | `result` |
| `mailmux_proc_mailtx_llm_calls_total` | `result` |
| `mailmux_proc_mailtx_firefly_requests_total` | `operation`, `result` |
| `mailmux_proc_mailtx_account_match_total` | `method` |
| `mailmux_proc_mailtx_transfer_legs_stored_total` | — |
| `mailmux_proc_mailtx_transfer_coalesced_total` | — |
| `mailmux_proc_mailtx_transfer_expired_total` | — |

## Test plan

- [ ] Build both crates: `cargo build` in `mailmux/` and `mailtx/`
- [ ] Existing mailmux tests pass: `cargo test` in `mailmux/`
- [ ] Run mailtx dry-run against a real event and confirm stdout is valid `ProcessorOutput` JSON with a `metrics` array
- [ ] Hit mailmux `/metrics` after a mailtx run and confirm `mailmux_proc_mailtx_*` counters appear
- [ ] Verify a command processor that outputs plain text (not JSON) still works correctly — the fallback path in `command.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)