### PR TITLE
fix: validate TLS CA certificate file path before reading

### DIFF
--- a/mailmux/src/imap/connection.rs
+++ b/mailmux/src/imap/connection.rs
@@ -141,8 +141,37 @@ impl ImapConnection {
                     root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
 
                     if let Some(ca_file) = &config.tls_ca_file {
-                        let pem = std::fs::read(ca_file)
-                            .with_context(|| format!("reading TLS CA file '{ca_file}'"))?;
+                        let ca_path = std::path::Path::new(ca_file)
+                            .canonicalize()
+                            .with_context(|| format!("resolving TLS CA file path '{ca_file}'"))?;
+                        if !ca_path.is_file() {
+                            bail!("TLS CA path '{}' is not a regular file", ca_path.display());
+                        }
+                        #[cfg(unix)]
+                        {
+                            use std::os::unix::fs::PermissionsExt;
+                            let mode = std::fs::metadata(&ca_path)
+                                .with_context(|| {
+                                    format!(
+                                        "reading metadata for TLS CA file '{}'",
+                                        ca_path.display()
+                                    )
+                                })?
+                                .permissions()
+                                .mode();
+                            if mode & 0o002 != 0 {
+                                bail!(
+                                    "TLS CA file '{}' is world-writable (mode {:o}); \
+                                     fix permissions before use",
+                                    ca_path.display(),
+                                    mode & 0o777,
+                                );
+                            }
+                        }
+                        let pem = std::fs::read(&ca_path)
+                            .with_context(|| {
+                                format!("reading TLS CA file '{}'", ca_path.display())
+                            })?;
                         let certs: Vec<CertificateDer<'static>> =
                             rustls_pemfile::certs(&mut pem.as_slice())
                                 .collect::<Result<_, _>>()


### PR DESCRIPTION
## Summary
- Canonicalize `tls_ca_file` path via `Path::canonicalize()` to resolve symlinks and relative components
- Reject paths that don't point to a regular file
- Reject world-writable CA files on Unix (mode `o+w`) to prevent tampered certificates

Closes #22

## Test plan
- [x] All existing tests pass
- [ ] Manual: configure `tls_ca_file` with a symlinked path — should resolve and load
- [ ] Manual: configure `tls_ca_file` pointing to a directory — should fail with clear error
- [ ] Manual: set CA file to world-writable (`chmod o+w`) — should fail with permission error

🤖 Generated with [Claude Code](https://claude.com/claude-code)